### PR TITLE
history time check that the non-digit is d, h, m

### DIFF
--- a/src/modules/chanmodes/history.c
+++ b/src/modules/chanmodes/history.c
@@ -439,6 +439,10 @@ int history_parse_chanmode(Channel *channel, const char *param, int *lines, long
 	{
 		if (!isdigit(*q))
 		{
+			if (*q && *q != 'd' && *q != 'h' && *q != 'm')
+			{
+				return 0;
+			}
 			contains_non_digit = 1;
 			break;
 		}


### PR DESCRIPTION
strengthen the check of time by verifying that the non-digit is d, h, m

If we provide a time like 1111ttttttttttt the value was accept and convert to 1111m. This path returns an error if the time unit does not have one of these three: d,h,m